### PR TITLE
struct and make produce equal structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # The directory Mix will write compiled artifacts to.
 /_build
 
+# Bench results
+/bench/graph
+/bench/snapshots
+
 # If you run "mix test --cover", coverage assets end up here.
 /cover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,19 @@ language: elixir
 dist: trusty
 sudo: false
 
-elixir:
-  - 1.3.4
-  - 1.4.5
-  - 1.5.3
-
-otp_release: 19.0
+matrix:
+  include:
+  - elixir: 1.7.2
+    otp_release: 21.0
+  - elixir: 1.7.2
+    otp_release: 20.3.1
+  - elixir: 1.6.6
+    otp_release: 19.3
+  - elixir: 1.5.3
+    otp_release: 18.3
+  - elixir: 1.5.3
+    otp_release: 17.5
+  - elixir: 1.4.5
+    otp_release: 17.5
+  - elixir: 1.3.4
+    otp_release: 17.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+## v2.0.0
+
+* Enhancements
+  * Structs created from `struct/1,2` and `make/1,2` are now equal
+  * Structs that have required fields returns error when creating from `struct/1,2`
+
 ## v1.2.0
 
 * Enhancements

--- a/bench/snapshots/2016-12-22_12-36-34.snapshot
+++ b/bench/snapshots/2016-12-22_12-36-34.snapshot
@@ -1,3 +1,0 @@
-duration:1.0;mem stats:false;sys mem stats:false
-module;test;tags;iterations;elapsed
-StructBench	complex		200000	1871133

--- a/lib/construct/cast.ex
+++ b/lib/construct/cast.ex
@@ -65,7 +65,7 @@ defmodule Construct.Cast do
   @spec make(atom | types, map, options) :: {:ok, Construct.t | map} | {:error, term}
   def make(struct_or_types, params, opts \\ [])
   def make(module, params, opts) when is_atom(module) do
-    make(make_struct_instance(module), collect_types(module), params, opts)
+    make_struct(make_struct_instance(module), collect_types(module), params, opts)
   end
   def make(types, params, opts) do
     cast_params(types, params, opts)
@@ -86,7 +86,7 @@ defmodule Construct.Cast do
   @doc false
   defp make_struct_instance(module) do
     try do
-      module.__struct__
+      struct(module)
     rescue
       UndefinedFunctionError ->
         raise Construct.Error, "undefined structure #{inspect(module)}, it is not defined or does not exist"
@@ -94,7 +94,7 @@ defmodule Construct.Cast do
   end
 
   @doc false
-  defp make(%{__struct__: _module} = struct, types, params, opts) do
+  defp make_struct(%{__struct__: _module} = struct, types, params, opts) do
     make_map? = Keyword.get(opts, :make_map, false)
 
     case cast_params(types, params, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -24,10 +24,7 @@ defmodule Construct.Mixfile do
   end
 
   defp preferred_cli_env do
-    ["coveralls": :test,
-     "coveralls.detail": :test,
-     "coveralls.post": :test,
-     "coveralls.html": :test]
+    [coveralls: :test]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Construct.Mixfile do
 
   def project do
     [app: :construct,
-     version: "1.2.0",
+     version: "2.0.0",
      elixir: "~> 1.3",
      deps: deps(),
      test_coverage: [tool: ExCoveralls],

--- a/test/integration/struct_test.exs
+++ b/test/integration/struct_test.exs
@@ -1,0 +1,86 @@
+defmodule Construct.Integration.StructTest do
+  use Construct.TestCase
+
+  defmodule Test0 do
+    use Construct
+
+    structure do
+      field :a do
+        field :b do
+          field :c, :string, default: "test"
+          field :d, :string, default: "test"
+        end
+      end
+
+      field :e, :string, default: "test"
+    end
+  end
+
+  defmodule Test1 do
+    use Construct
+
+    structure do
+      field :a do
+        field :b do
+          field :c, :string
+          field :d, :string, default: "test"
+        end
+      end
+
+      field :e
+    end
+  end
+
+  defmodule Test2 do
+    use Construct
+
+    structure do
+      field :test, Test2
+    end
+  end
+
+  test "struct should be equal with make" do
+    assert struct!(Test0) == Test0.make!()
+  end
+
+  test "struct have nested structs with all defaults" do
+    assert %Test0{a: %Test0.A{b: %Test0.A.B{c: "test", d: "test"}}, e: "test"}
+        == struct!(Test0)
+  end
+
+  test "struct have nested structs without defaults in some fields" do
+    assert_raise(ArgumentError, enforce_keys_message(Test1, [:e, :a]), fn ->
+      struct!(Test1)
+    end)
+
+    assert {:error, %{e: :missing, a: :missing}} == Test1.make()
+
+    assert_raise(ArgumentError, enforce_keys_message(Test1, [:a]), fn ->
+      struct!(Test1, %{e: "test"})
+    end)
+
+    assert {:error, %{a: :missing}} == Test1.make(%{e: "test"})
+
+    assert_raise(ArgumentError, enforce_keys_message(Test1.A, [:b]), fn ->
+      struct!(Test1.A)
+    end)
+
+    assert {:error, %{b: :missing}} == Test1.A.make()
+
+    assert_raise(ArgumentError, enforce_keys_message(Test1.A.B, [:c]), fn ->
+      struct!(Test1.A.B)
+    end)
+
+    assert {:error, %{c: :missing}} == Test1.A.B.make()
+  end
+
+  test "cycle deps" do
+    assert_raise(ArgumentError, enforce_keys_message(Test2, [:test]), fn ->
+      struct!(Test2)
+    end)
+  end
+
+  defp enforce_keys_message(mod, keys) do
+    "the following keys must also be given when building struct #{inspect(mod)}: #{inspect(keys)}"
+  end
+end

--- a/test/integration/struct_test.exs
+++ b/test/integration/struct_test.exs
@@ -39,6 +39,24 @@ defmodule Construct.Integration.StructTest do
     end
   end
 
+  defmodule Test30 do
+    use Construct
+
+    structure do
+      field :a, :string
+    end
+  end
+
+  defmodule Test31 do
+    use Construct
+
+    structure do
+      include Test30
+
+      field :a, :string, default: "test"
+    end
+  end
+
   test "struct should be equal with make" do
     assert struct!(Test0) == Test0.make!()
   end
@@ -46,6 +64,10 @@ defmodule Construct.Integration.StructTest do
   test "struct have nested structs with all defaults" do
     assert %Test0{a: %Test0.A{b: %Test0.A.B{c: "test", d: "test"}}, e: "test"}
         == struct!(Test0)
+  end
+
+  test "struct default overwriting should reset enforce_keys" do
+    assert %Test31{}
   end
 
   test "struct have nested structs without defaults in some fields" do


### PR DESCRIPTION
Now you can create structure without any cost if you have default values for all fields:

```elixir
iex(1)> defmodule Test0 do
...(1)>   use Construct
...(1)>
...(1)>   structure do
...(1)>     field :a do
...(1)>       field :b do
...(1)>         field :c, :string, default: "test"
...(1)>         field :d, :string, default: "test"
...(1)>       end
...(1)>     end
...(1)>
...(1)>     field :e, :string, default: "test"
...(1)>   end
...(1)> end
{:module, Test0, ...}

iex(2)> a = %Test0{}
%Test0{a: %Test0.A{b: %Test0.A.B{c: "test", d: "test"}}, e: "test"}

iex(3)> {:ok, b} = Test0.make
{:ok, %Test0{a: %Test0.A{b: %Test0.A.B{c: "test", d: "test"}}, e: "test"}}

iex(4)> a == b
true
```

This PR also fix issue when field require values to pass in `make/2` functions, but when you create that structure in Elixir manner (like `%Test0{}`) — it returns invalid structure, that don't equals with created one from `make/2`:

```elixir
iex(1)> defmodule Test1 do
...(1)>   use Construct
...(1)>
...(1)>   structure do
...(1)>     field :a
...(1)>     field :b, :string, default: "test1"
...(1)>   end
...(1)> end
{:module, Test1, ...}

iex(2)> Test1.make
{:error, %{a: :missing}}

iex(3)> %Test1{}
** (ArgumentError) the following keys must also be given when building struct Test1: [:a]
    expanding struct: Test1.__struct__/1
    iex:3: (file)
```