### PR TITLE
fix warnings for elixir 1.10

### DIFF
--- a/test/integration/make_test.exs
+++ b/test/integration/make_test.exs
@@ -434,6 +434,7 @@ defmodule Construct.Integration.MakeTest do
       include include1
 
       field :a, :integer, default: 0
+      field :b, :string
       field :c, :string, default: "from module"
     end
 


### PR DESCRIPTION
```elixir
warning: duplicate key :c found in struct
  (elixir 1.10.1) lib/kernel/utils.ex:119: Kernel.Utils.warn_on_duplicate_struct_key/1
  (elixir 1.10.1) lib/kernel/utils.ex:98: Kernel.Utils.defstruct/2
  (stdlib 3.11.1) erl_eval.erl:680: :erl_eval.do_apply/6
  (stdlib 3.11.1) erl_eval.erl:449: :erl_eval.expr/5
  (elixir 1.10.1) src/elixir.erl:278: :elixir.recur_eval/3
  (elixir 1.10.1) src/elixir.erl:263: :elixir.eval_forms/3
  (elixir 1.10.1) lib/module.ex:614: Module.eval_quoted/4
  test/integration/make_test.exs:433: (module)
  ...
```

```elixir
warning: Code.ensure_compiled?/1 is deprecated. Use Code.ensure_compiled/1 instead (see the proper disclaimers in its docs)
Found at 3 locations:
  lib/construct.ex:213: Construct.construct_definition?/1
  lib/construct.ex:405: Construct.check_type_complex!/2
  lib/construct.ex:460: Construct.construct_module?/1
```