### PR TITLE
added new types and prettified docs

### DIFF
--- a/lib/construct/hooks/map.ex
+++ b/lib/construct/hooks/map.ex
@@ -1,4 +1,6 @@
 defmodule Construct.Hooks.Map do
+  @moduledoc false
+
   defmacro __using__(_opts \\ []) do
     quote do
       structure_compile_hook :post do

--- a/lib/construct/hooks/omit_default.ex
+++ b/lib/construct/hooks/omit_default.ex
@@ -1,4 +1,6 @@
 defmodule Construct.Hooks.OmitDefault do
+  @moduledoc false
+
   defmacro __using__(_opts \\ []) do
     quote do
       structure_compile_hook :post do

--- a/lib/construct/type.ex
+++ b/lib/construct/type.ex
@@ -130,6 +130,10 @@ defmodule Construct.Type do
       iex> cast(:string, [1, 2, 3])
       :error
 
+      iex> cast({Construct.Types.Enum, [:a, :b, :c]}, :a)
+      {:ok, :a}
+      iex> cast({Construct.Types.Enum, [:a, :b, :c]}, :d)
+      {:error, passed_value: :d, valid_values: [:a, :b, :c]}
   """
   @spec cast(t, term, options) :: cast_ret | any
     when options: Keyword.t()

--- a/lib/construct/type_c.ex
+++ b/lib/construct/type_c.ex
@@ -1,3 +1,9 @@
 defmodule Construct.TypeC do
+  @moduledoc """
+  Provides a way to create parametrized types.
+
+  See `Construct.Types.Enum` implementation for more information.
+  """
+
   @callback castc(term, arg :: term) :: Construct.Type.cast_ret()
 end

--- a/lib/construct/types/comma_list.ex
+++ b/lib/construct/types/comma_list.ex
@@ -1,0 +1,41 @@
+defmodule Construct.Types.CommaList do
+  @moduledoc """
+  Extracts list of separated by comma values from string.
+
+  You can use it alone, just for splitting values:
+
+      defmodule Structure do
+        use Construct do
+          field :values, Construct.Types.CommaList
+        end
+      end
+
+      iex> Structure.make!(values: "foo,bar,baz,42")
+      %Structure{values: ["foo", "bar", "baz", "42"]}
+
+      iex> Structure.make!(values: ["foo", 42])
+      %Structure{values: ["foo", 42]}
+
+  Also you can compose it with other types:
+
+      defmodule UserInfoRequest do
+        use Construct do
+          field :user_ids, [Construct.Types.CommaList, {:array, :integer}]
+        end
+      end
+
+      iex> UserInfoRequest.make!(%{user_ids: "1,2,42"})
+      %UserInfoRequest{user_ids: [1, 2, 42]}
+
+      iex> UserInfoRequest.make(%{user_ids: "1,foo"})
+      {:error, %{user_ids: :invalid}}
+  """
+
+  @behaviour Construct.Type
+
+  @impl true
+  def cast(""), do: {:ok, []}
+  def cast(v) when is_binary(v), do: {:ok, String.split(v, ",")}
+  def cast(v) when is_list(v), do: {:ok, v}
+  def cast(_), do: :error
+end

--- a/lib/construct/types/enum.ex
+++ b/lib/construct/types/enum.ex
@@ -1,0 +1,32 @@
+defmodule Construct.Types.Enum do
+  @moduledoc """
+  Implements an abstract enum type.
+
+  ## Usage
+
+      defmodule MyApp.Order do
+        use Construct do
+          field :type, {Construct.Types.Enum, [:delivery, :pickup]}
+        end
+      end
+
+  Then you can validate that `:type` field accepts only specified
+  values.
+
+      iex> MyApp.Order.make(%{type: :delivery})
+      {:ok, %MyApp.Order{type: :delivery}}
+      iex> MyApp.Order.make(%{type: :other})
+      {:error, %{type: passed_value: :other, valid_values: [:delivery, :pickup]}}
+  """
+
+  @behaviour Construct.TypeC
+
+  @impl true
+  def castc(value, variants) when is_list(variants) do
+    if value in variants do
+      {:ok, value}
+    else
+      {:error, passed_value: value, valid_values: variants}
+    end
+  end
+end

--- a/lib/construct/types/uuid.ex
+++ b/lib/construct/types/uuid.ex
@@ -1,0 +1,23 @@
+defmodule Construct.Types.UUID do
+  @moduledoc """
+  Checks that provided binary is UUID-like string:
+
+      defmodule Structure do
+        use Construct do
+          field :value, Construct.Types.UUID
+        end
+      end
+
+      iex> Structure.make!(value: "fd4ddf80-a7d9-4af8-b46c-26fc4566d92c")
+      %Structure{value: "fd4ddf80-a7d9-4af8-b46c-26fc4566d92c"}
+
+      iex> Structure.make(value: "invalid")
+      {:error, %{value: :invalid}}
+  """
+
+  @behaviour Construct.Type
+
+  @impl true
+  def cast(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>> = v), do: {:ok, v}
+  def cast(_), do: :error
+end

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,14 @@ defmodule Construct.Mixfile do
     [
       main: "readme",
       source_url: "https://github.com/ExpressApp/construct",
-      extras: ["README.md"]
+      extras: ["README.md"],
+      groups_for_modules: [
+        "Provided types": [
+          Construct.Types.CommaList,
+          Construct.Types.Enum,
+          Construct.Types.UUID
+        ]
+      ]
     ]
   end
 end

--- a/test/construct/cast_test.exs
+++ b/test/construct/cast_test.exs
@@ -2,6 +2,7 @@ defmodule Construct.CastTest do
   use ExUnit.Case
 
   alias Construct.Cast
+  alias Construct.Types.CommaList
 
   doctest Construct.Cast, import: true
 

--- a/test/construct/type_test.exs
+++ b/test/construct/type_test.exs
@@ -2,6 +2,7 @@ defmodule Construct.TypeTest do
   use Construct.TestCase
 
   alias Construct.Type
+  alias Construct.Types.CommaList
 
   doctest Construct.Type, import: true
 

--- a/test/construct/types/uuid_test.exs
+++ b/test/construct/types/uuid_test.exs
@@ -1,0 +1,16 @@
+defmodule Construct.Types.UUIDTest do
+  use Construct.TestCase
+
+  alias Construct.Types.UUID
+
+  describe "#cast" do
+    test "oks on a valid UUID" do
+      uuid = "fd4ddf80-a7d9-4af8-b46c-26fc4566d92c"
+      assert {:ok, ^uuid} = Construct.Type.cast(UUID, uuid)
+    end
+
+    test "returns an error on an invalid UUID" do
+      assert :error = Construct.Type.cast(UUID, "invalid")
+    end
+  end
+end

--- a/test/integration/make_test.exs
+++ b/test/integration/make_test.exs
@@ -1,6 +1,10 @@
 defmodule Construct.Integration.MakeTest do
   use Construct.TestCase
 
+  # For some reason it keeps emitting a warning about an unused alias
+  # while it's actually used.
+  alias Construct.Types.CommaList, warn: false
+
   test "with simple stupid params" do
     module = create_construct do
       field :key
@@ -84,23 +88,23 @@ defmodule Construct.Integration.MakeTest do
 
   test "field with type `[t, {t, ...}]`" do
     module = create_construct do
-      field :key, [:string, {EnumT, ~w(A B C)}]
+      field :key, [:string, {Construct.Types.Enum, ~w(A B C)}]
     end
 
-    assert {:ok, %{key: "A"}} = make(module, %{key: "a"})
-    assert {:error, %{key: :invalid}} = make(module, %{key: "d"})
+    assert {:ok, %{key: "A"}} = make(module, %{key: "A"})
+    assert {:error, %{key: [passed_value: "D", valid_values: ["A", "B", "C"]]}} = make(module, %{key: "D"})
     assert {:error, %{key: :invalid}} = make(module, %{key: 123})
     assert {:error, %{key: :missing}} = make(module, %{})
   end
 
   test "field with type `[t, {:array, {t, ...}}]`" do
     module = create_construct do
-      field :key, [CommaList, {:array, {EnumT, ~w(A B C)}}]
+      field :key, [CommaList, {:array, {Construct.Types.Enum, ~w(A B C)}}]
     end
 
-    assert {:ok, %{key: ["A"]}} = make(module, %{key: "a"})
-    assert {:ok, %{key: ["A", "C", "B"]}} = make(module, %{key: "a,c,b"})
-    assert {:error, %{key: :invalid}} = make(module, %{key: "a,d"})
+    assert {:ok, %{key: ["A"]}} = make(module, %{key: "A"})
+    assert {:ok, %{key: ["A", "C", "B"]}} = make(module, %{key: "A,C,B"})
+    assert {:error, %{key: [passed_value: "D", valid_values: ["A", "B", "C"]]}} = make(module, %{key: "A,D"})
     assert {:error, %{key: :invalid}} = make(module, %{key: 123})
     assert {:error, %{key: :missing}} = make(module, %{})
   end
@@ -295,7 +299,7 @@ defmodule Construct.Integration.MakeTest do
     end
 
     assert {:error,
-             %{nested: %{error: :missing, value: nil, expect: "array of Construct.Integration.MakeTest_287 is expected"}}}
+             %{nested: %{error: :missing, value: nil, expect: "array of Construct.Integration.MakeTest_291 is expected"}}}
         == make(module2, %{}, opts)
 
     assert {:error,
@@ -360,7 +364,7 @@ defmodule Construct.Integration.MakeTest do
       field :nested, {:array, module1_type}
     end
 
-    assert {:error, %{nested: %{error: :missing, value: nil, expect: "array of Construct.Integration.MakeTest_352 is expected"}}}
+    assert {:error, %{nested: %{error: :missing, value: nil, expect: "array of Construct.Integration.MakeTest_356 is expected"}}}
         == make(module2, %{}, opts)
 
     assert {:error, %{nested: [%{error: %{key: %{error: :missing, expect: "Comment is expected", value: nil}}, index: 0}]}}

--- a/test/support/types.ex
+++ b/test/support/types.ex
@@ -8,13 +8,6 @@ defmodule EctoType do
   def cast(_), do: :error
 end
 
-defmodule CommaList do
-  def cast(""), do: {:ok, []}
-  def cast(v) when is_binary(v), do: {:ok, String.split(v, ",")}
-  def cast(v) when is_list(v), do: {:ok, v}
-  def cast(_), do: :error
-end
-
 defmodule CustomTypeInvalid do
   def cast(_), do: :invalid_ret
 end
@@ -27,18 +20,4 @@ defmodule Nilable do
 
   def castc(nil, _), do: {:ok, nil}
   def castc(val, type), do: Construct.Type.cast(type, val)
-end
-
-defmodule EnumT do
-  @behaviour Construct.TypeC
-
-  def castc(val, enums) do
-    val = String.upcase(val)
-
-    if val in enums do
-      {:ok, val}
-    else
-      :error
-    end
-  end
 end


### PR DESCRIPTION
This PR adds some new types for construct's schemas. The docs for the types are grouped (new "Provided types" group is created). Also, some modules were excluded from the docs.

New types include:
- Construct.Types.CommaList
- Construct.Types.Enum
- Construct.Types.UUID

Modules excluded from the docs:
- Construct.Hooks.OmitDefault
- Construct.Hooks.Map